### PR TITLE
Revert "thea: Use prebuilt charge_only_mode"

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -42,9 +42,6 @@ vendor/lib/libmmcamera_imx179.so
 vendor/lib/libmmcamera_ov10820.so
 vendor/lib/libmmcamera_tintless_bg_pca_algo.so
 
-# Charger
-bin/charge_only_mode
-
 # Chromatix
 lib/libchromatix_ar0543_common.so
 lib/libchromatix_ar0543_default_video.so


### PR DESCRIPTION
This reverts commit bd1f831dd8d23acd90ae22147470c8ab6bd15808.

Change-Id: Iaca3ce4166c72b30838e804c848c1d2f2121d74e